### PR TITLE
feat(config): 添加环境配置和路径别名支持

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+# API URL Configuration
+VITE_API_URL=http://43.143.228.56:8000

--- a/.env.mock
+++ b/.env.mock
@@ -1,0 +1,2 @@
+# API URL Configuration for Mock Environment
+VITE_API_URL=http://127.0.0.1:4523/m2/6178223-5870624-default

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+      
+    },
+    "target": "es6",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "jsx": "preserve"
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/creativetimofficial/vue-notus",
   "license": "MIT",
   "scripts": {
-    "serve": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
+    "serve": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve --mode development",
+    "serve:mock": "set NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve --mode mock",
     "build": "set NODE_OPTIONS=--openssl-legacy-provider && cross-env PUBLIC_URL=/ cross-env CI=false vue-cli-service build && gulp licenses",
     "lint": "vue-cli-service lint",
     "build:tailwind": "tailwind build src/assets/styles/index.css -o src/assets/styles/tailwind.css",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 // vue.config.js
 const { codeInspectorPlugin } = require('code-inspector-plugin');
+const path = require('path');
 
 module.exports = {
   runtimeCompiler: true,
@@ -9,5 +10,18 @@ module.exports = {
         bundler: 'webpack',
       })
     );
+    
+    // 添加对node_modules的处理
+    config.resolve.modules
+      .add('node_modules')
+      .add(path.resolve(__dirname, './node_modules'));
+  },
+  configureWebpack: {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+        'utils': path.resolve(__dirname, 'src/utils'),
+      }
+    },
   },
 };


### PR DESCRIPTION
- 新增开发环境(.env.development)和模拟环境(.env.mock)配置
- 添加jsconfig.json实现路径别名, 现在可以自动补全"@/"开头的路径
- 更新vue.config.js，添加@和utils路径别名
- 增加serve:mock命令用于模拟数据环境