### PR TITLE
feat(note): 笔记页面和文献阅读页面正确区分是否属于组织

### DIFF
--- a/src/api/group_note.js
+++ b/src/api/group_note.js
@@ -2,34 +2,6 @@ import http from '@/utils/http';
 
 /**
  * 笔记相关 API
- */
-
-/**
- * 获取笔记列表
- * @param {Object} params - 查询参数
- * @param {number} [params.id] - 笔记 ID
- * @param {number} [params.page] - 页码
- * @param {number} [params.page_size] - 每页大小
- * @param {number} [params.article_id] - 文献 ID
- * @returns {Promise<any>} 笔记列表数据
- */
-export const getNotes = (params = {}) => {
-    return http.get('/notes/get', { params });
-};
-
-/**
- * 获取笔记标题列表
- * @param {Object} params - 查询参数
- * @param {number} [params.id] - 笔记 ID
- * @param {number} [params.page] - 页码
- * @param {number} [params.page_size] - 每页大小
- * @param {number} [params.article_id] - 文献 ID
- * @returns {Promise<any>} 笔记标题列表数据
- */
-export const getNoteTitles = (params = {}) => {
-    return http.get('/notes/title', { params });
-};
-
 /**
  * 创建笔记
  * @param {Object} data - 笔记数据
@@ -70,10 +42,19 @@ export const deleteNote = (noteId) => {
     return http.delete(`/notes/${noteId}`);
 };
 
-export default {
-    getNotes,
-    getNoteTitles,
-    createNote,
-    updateNote,
-    deleteNote
+/**
+ * 获取笔记编辑权限
+ * @param {number|string} noteId - 笔记 ID
+ * @returns {Promise<any>} 编辑权限结果
+ */
+export const getEditPermission = (noteId) => {
+    return http.get('/group/ifEditNote', { params: { note_id: noteId } });
 };
+
+export default {
+  createNote,
+  updateNote,
+  deleteNote,
+  getEditPermission,
+};
+

--- a/src/api/note.js
+++ b/src/api/note.js
@@ -57,7 +57,7 @@ export const updateNote = (noteId, data) => {
   if (data.content !== undefined) params.content = data.content;
   if (data.title !== undefined) params.title = data.title;
   
-  return http.put(`/notes/${noteId}`, null, { params });
+  return http.post(`/notes/${noteId}`, params);
 };
 
 /**

--- a/src/api/note_unified.js
+++ b/src/api/note_unified.js
@@ -41,20 +41,26 @@ class NoteAPI {
         note_content: content
       })
     } else {
-      return http.put(`/notes/${note_id}`, {
-        content,
-        title
+      return http.put(`/notes/${note_id}`, null, {
+        params: {
+          content,
+          title
+        }
       })
     }
   }
 
   /**
    * 删除笔记
-   * @param {number|string} noteId 笔记ID
+   * @param {Object} params 删除参数
+   * @param {number|string} params.note_id 笔记ID
+   * @param {boolean} [params.isGroup] 是否是组织笔记
    * @returns {Promise} 返回删除结果
    */
-  static async deleteNote(noteId) {
-    return http.delete(`/notes/${noteId}`)
+  static async deleteNote(params) {
+    const { note_id } = params
+    // 目前两种笔记都使用相同的删除接口，如果将来接口分开，可以通过 isGroup 判断
+    return http.delete(`/notes/${note_id}`)
   }
 
   /**
@@ -65,10 +71,41 @@ class NoteAPI {
    * @param {number} [params.page] 页码(可选)
    * @param {number} [params.page_size] 每页数量(可选)
    * @param {string} [params.query] 搜索关键词(可选)
+   * @param {boolean} [params.isGroup] 是否获取组织笔记
    * @returns {Promise} 返回笔记列表数据
    */
   static async getNotes(params) {
-    return http.get('/notes/get', { params })
+    const { ...queryParams } = params
+    // 目前个人笔记和组织笔记使用相同的获取接口，如果将来接口分开，可以通过 isGroup 判断
+    return http.get('/notes/get', { params: queryParams })
+  }
+
+  /**
+   * 获取笔记标题列表
+   * @param {Object} params 查询参数
+   * @param {number} [params.id] 指定笔记ID(可选)
+   * @param {number} [params.article_id] 指定文献ID(可选)
+   * @param {number} [params.page] 页码(可选)
+   * @param {number} [params.page_size] 每页数量(可选)
+   * @param {boolean} [params.isGroup] 是否获取组织笔记
+   * @returns {Promise} 返回笔记标题列表
+   */
+  static async getNoteTitles(params) {
+    const { ...queryParams } = params
+    // 目前个人笔记和组织笔记使用相同的获取接口，如果将来接口分开，可以通过 isGroup 判断
+    return http.get('/notes/title', { params: queryParams })
+  }
+
+  /**
+   * 检查组织笔记编辑权限
+   * @param {number|string} noteId 笔记ID
+   * @returns {Promise<boolean>} 是否有编辑权限
+   */
+  static async checkGroupNoteEditPermission(noteId) {
+    const response = await http.get('/group/ifEditNote', {
+      params: { note_id: noteId }
+    })
+    return response.editable
   }
 }
 

--- a/src/api/note_unified.js
+++ b/src/api/note_unified.js
@@ -41,12 +41,11 @@ class NoteAPI {
         note_content: content
       })
     } else {
-      return http.put(`/notes/${note_id}`, null, {
-        params: {
-          content,
-          title
-        }
-      })
+      // 构建查询参数
+      const params = {};
+      if (content !== undefined) params.content = content;
+      if (title !== undefined) params.title = title;
+      return http.post(`/notes/${note_id}`, params);
     }
   }
 

--- a/src/api/note_unified.js
+++ b/src/api/note_unified.js
@@ -1,0 +1,75 @@
+import http from '@/utils/http'
+
+/**
+ * 统一的笔记 API 类
+ * 处理个人笔记和组织笔记的所有操作
+ */
+class NoteAPI {
+  /**
+   * 创建笔记
+   * @param {Object} params 笔记参数
+   * @param {number} params.article_id 所属文献ID 
+   * @param {string} params.content 笔记内容
+   * @param {string} params.title 笔记标题
+   * @param {boolean} [params.isGroup] 是否是组织笔记
+   * @returns {Promise} 返回创建结果
+   */
+  static async createNote(params) {
+    const { isGroup, ...noteData } = params
+    if (isGroup) {
+      return http.post('/group/newNote', noteData)
+    } else {
+      return http.post('/notes/create', noteData)
+    }
+  }
+
+  /**
+   * 更新笔记
+   * @param {Object} params 更新参数
+   * @param {number|string} params.note_id 笔记ID
+   * @param {string} [params.content] 笔记内容(可选)
+   * @param {string} [params.title] 笔记标题(可选)
+   * @param {boolean} [params.isGroup] 是否是组织笔记
+   * @returns {Promise} 返回更新结果
+   */
+  static async updateNote(params) {
+    const { isGroup, note_id, content, title } = params
+    if (isGroup) {
+      return http.post('/group/changeNote', {
+        note_id,
+        note_title: title,
+        note_content: content
+      })
+    } else {
+      return http.put(`/notes/${note_id}`, {
+        content,
+        title
+      })
+    }
+  }
+
+  /**
+   * 删除笔记
+   * @param {number|string} noteId 笔记ID
+   * @returns {Promise} 返回删除结果
+   */
+  static async deleteNote(noteId) {
+    return http.delete(`/notes/${noteId}`)
+  }
+
+  /**
+   * 获取笔记列表
+   * @param {Object} params 查询参数
+   * @param {number} [params.id] 指定笔记ID(可选)
+   * @param {number} [params.article_id] 指定文献ID(可选)
+   * @param {number} [params.page] 页码(可选)
+   * @param {number} [params.page_size] 每页数量(可选)
+   * @param {string} [params.query] 搜索关键词(可选)
+   * @returns {Promise} 返回笔记列表数据
+   */
+  static async getNotes(params) {
+    return http.get('/notes/get', { params })
+  }
+}
+
+export default NoteAPI

--- a/src/components/Editor/JieNoteEditor.vue
+++ b/src/components/Editor/JieNoteEditor.vue
@@ -18,7 +18,7 @@
 import { MdEditor } from 'md-editor-v3';
 import 'md-editor-v3/lib/style.css';
 import { ref, onMounted, onBeforeUnmount, watch, defineProps, defineEmits, defineExpose } from 'vue';
-import { updateNote, getNotes } from '@/api/note';
+import NoteAPI from '@/api/note_unified';
 import { uploadImage } from '@/api/image';
 import { ElMessage } from 'element-plus';
 import {
@@ -41,6 +41,10 @@ const props = defineProps({
   modelValue: {
     type: String,
     default: '',
+  },
+  is_group: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -111,13 +115,18 @@ const saveNote = async (currentContent, showNotification = false) => {
   updating.value = true;
 
   try {
-    await updateNote(props.noteId, { content: currentContent });
+    await NoteAPI.updateNote({
+      note_id: props.noteId,
+      content: currentContent,
+      isGroup: props.is_group
+    });
+
     if (showNotification) {
-      ElMessage.success('笔记已保存'); // 手动保存时显示
+      ElMessage.success('笔记已保存');
     }
-    hasChanges.value = false; // 保存成功后重置标记
+    hasChanges.value = false;
   } catch (e) {
-    ElMessage.error(`保存失败: ${e.message}`); // 统一错误信息
+    ElMessage.error(`保存失败: ${e.message}`);
     console.error('保存失败', e);
   } finally {
     updating.value = false;
@@ -147,13 +156,12 @@ const handleUploadImg = async (files, callback) => {
 // 获取笔记内容
 const fetchNoteContent = async (noteId) => {
   try {
-    const response = await getNotes({ id: noteId });
-    if (
-      response &&
-      response.status === 200 &&
-      response.data.notes &&
-      response.data.notes.length > 0
-    ) {
+    const response = await NoteAPI.getNotes({
+      id: noteId,
+      isGroup: props.is_group
+    });
+    
+    if (response?.data?.notes?.[0]) {
       content.value = response.data.notes[0].content || '';
       emit('update:modelValue', content.value);
       return content.value;

--- a/src/components/Tree/SimpleTree.vue
+++ b/src/components/Tree/SimpleTree.vue
@@ -731,7 +731,7 @@ export default {
       // 检查是否是文献节点或笔记节点
       console.log("handleRead, node.level:", node.level, "depth:", data.depth)
       if (node.level === 2 && data.depth === 1) {  // PDF nodes: level 2 in tree, depth 1 in data
-        router.push(`/paper-note?article_id=${data.true_id}`);
+        router.push(`/paper-note?article_id=${data.true_id}&is_group=true`); // 在组织页面中，is_group为true
       } else if (node.level === 3 && data.depth === 2) {  // 笔记节点：level 3 in tree, depth 2 in data
         router.push(`/note/${data.true_id}`);
       } else {
@@ -805,7 +805,7 @@ export default {
     const handleNodeClick = (data) => {
       // 根据节点类型决定操作
       if (data.depth === 1) { // 文献节点
-        router.push(`/paper-note?article_id=${data.true_id}`);
+        router.push(`/paper-note?article_id=${data.true_id}&is_group=true`); // 添加is_group参数
       } else if (data.depth === 2) { // 笔记节点
         router.push(`/note/${data.true_id}`);
       } else {

--- a/src/layouts/PaperNote.vue
+++ b/src/layouts/PaperNote.vue
@@ -64,7 +64,8 @@
 import { Back, Loading } from '@element-plus/icons-vue';
 import http from '@/utils/http';
 import JieNoteEditor from '@/components/Editor/JieNoteEditor.vue';
-import { getNotes, createNote } from '@/api/note'; // 导入笔记相关 API
+import { getNotes } from '@/api/note'; // 导入笔记相关 API
+import NoteAPI from '@/api/note_unified'; // 笔记统一 API
 import { Splitpanes, Pane } from 'splitpanes';
 import 'splitpanes/dist/splitpanes.css';
 import { ElMessage } from 'element-plus';
@@ -132,10 +133,11 @@ export default {
           // 并通过 v-model 更新 editorContent。
         } else {
           // 没有关联笔记，创建新笔记
-          const createResponse = await createNote({
+          const createResponse = await NoteAPI.createNote({
             article_id: articleId,
             content: "",
-            title: `note` // 使用文献标题或ID作为笔记标题
+            title: `note`, // 使用文献标题或ID作为笔记标题
+            isGroup: this.is_group
           });
           
           if (createResponse && createResponse.data) {

--- a/src/layouts/PaperNote.vue
+++ b/src/layouts/PaperNote.vue
@@ -156,8 +156,11 @@ export default {
   },
   mounted() {
     const currentArticleId = this.$route.query.article_id;
+    const isGroup = this.$route.query.is_group === 'true';
     console.log("Current route:", this.$route);
+    
     if (currentArticleId) {
+      this.is_group = isGroup; // 从路由参数设置is_group
       this.fetchPdf(currentArticleId);
     } else {
       ElMessage.error("请先选择要阅读的文献");

--- a/src/views/admin/Dashboard.vue
+++ b/src/views/admin/Dashboard.vue
@@ -313,19 +313,21 @@
                 ref="treeRef"
             >
               <template #default="{ node, data }">
-                <div class="modern-node" @dblclick.stop="handleNodeClick(data)">
+                <div class="modern-node" @dblclick.stop="handleNodeDblClick(data)">
                   <!-- 预览 popover -->
                   <el-popover
                     v-if="previewEnabled && data.depth === 2"
                     placement="right-start"
                     :width="400"
                     trigger="hover"
-                    :hide-after="300"
+                    :hide-after="400"
                     :show-arrow="true"
                     :offset="12"
-                    :show-after="600"
+                    :show-after="300"
+                    transition="el-fade-in-linear"
                     popper-class="preview-popover"
                     @show="handlePreviewShow(data)"
+                    @before-enter="handlePreviewBeforeEnter(data)"
                   >
                     <template #default>
                       <div class="preview-content">
@@ -591,11 +593,25 @@ export default {
 
 
   setup() {
-    // 预览相关的状态
+    // 预览相关的状态和变量
     const previewEnabled = ref(false)
     const currentPreviewNote = ref(null)
     const previewCache = ref(new Map()) // 用于缓存预览内容
+    const previewLoadingDelay = ref(null) // 用于延迟加载动画
     
+    // 处理预览显示
+    // 预览加载前的处理
+    const handlePreviewBeforeEnter = (data) => {
+      // 清除之前的延迟加载定时器
+      if (previewLoadingDelay.value) {
+        clearTimeout(previewLoadingDelay.value);
+      }
+      // 如果没有缓存，显示加载状态
+      if (!previewCache.value.has(data.id)) {
+        currentPreviewNote.value = null;
+      }
+    }
+
     // 处理预览显示
     const handlePreviewShow = async (data) => {
       // 如果缓存中已有内容，直接使用缓存
@@ -604,7 +620,9 @@ export default {
         return;
       }
 
-      try {
+      // 设置延迟加载动画
+      previewLoadingDelay.value = setTimeout(async () => {
+        try {
         const response = await getNotes({ id: data.true_id });
         if (response.data && response.data.notes && response.data.notes.length > 0) {
           const note = {
@@ -620,8 +638,13 @@ export default {
       } catch (error) {
         console.error('预览加载失败:', error);
         ElMessage.error('预览加载失败：' + (error.message || '请稍后重试'));
+      } finally {
+        // 清除延迟加载定时器
+        clearTimeout(previewLoadingDelay.value);
+        previewLoadingDelay.value = null;
       }
-    }
+    }, 300); // 300ms后开始加载，避免频繁触发
+  }
     const router = useRouter()
 
     const showNewNoteDialog = ref(false)
@@ -918,18 +941,20 @@ export default {
       }
     }
 
-    const handleNodeClick = async (data) => {
-      // 如果预览模式已启用且点击了笔记节点，则不执行其他操作
-      if (previewEnabled.value && data.depth === 2) {
-        return;
-      }
-
-      // 常规点击处理逻辑保持不变
+    // 处理双击事件
+    const handleNodeDblClick = async (data) => {
+      // 直接处理跳转逻辑
       if (data.depth === 1) { // 文献节点
         router.push(`/paper-note?article_id=${data.true_id}`);
       } else if (data.depth === 2) { // 笔记节点
         router.push(`/note/${data.true_id}`);
-      } else {
+      }
+    }
+
+    // 处理普通点击事件
+    const handleNodeClick = (data) => {
+      // 只处理文件夹的展开/收起
+      if (data.depth === 0) {
         if (expandedKeys.value.has(data.id)) {
           handleNodeCollapse(data)
         } else {
@@ -1811,6 +1836,7 @@ export default {
       currentPreviewNote,
       togglePreview,
       handlePreviewShow,
+      handlePreviewBeforeEnter,
       handleCheck,
       findAllfolders,
       showCheckbox,
@@ -1820,6 +1846,7 @@ export default {
       showNewNoteDialog,
       newNoteForm,
       handleNodeClick,
+      handleNodeDblClick,
       toggleCheckbox,
       append,
       remove,
@@ -1899,7 +1926,15 @@ export default {
 
 .modern-node {
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: all 0.3s ease;
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &.hovering {
+    background-color: rgba(70, 160, 255, 0.05);
+  }
 
   .node-actions {
     /* 防止点击操作按钮时触发节点点击 */


### PR DESCRIPTION
fix(api): 文献阅读页面创建第一篇笔记要判断是否为组织文献
feat(note): 正确传递is_group字段
fix(api): updatNote use post instead of put
feat(editor): 添加is_group字段并正确使用
feat(api): 笔记的统一接口 api/note_unified.js
feat(api): group getEditPermission
feat(dashboard): 开启笔记预览后双击也可进入笔记编辑页